### PR TITLE
Add functionality to preselect mute and solo for audio tracks via DOM attributes

### DIFF
--- a/js/trackswitch.js
+++ b/js/trackswitch.js
@@ -165,7 +165,12 @@ Plugin.prototype.init = function() {
 
         this.element.find('ts-track').each(function(i) {
 
-            that.trackProperties[i] = { mute: false, solo: false, success: false, error: false, };
+            that.trackProperties[i] = {
+                mute: this.hasAttribute('mute'),  // <ts-track title="Track" mute>
+                solo: this.hasAttribute('solo'),  // <ts-track title="Track" solo>
+                success: false,
+                error: false
+            };
 
             // Append classes to '.track' depending on options (for styling and click binding)
             var tabview = that.options.tabview ? " tabs" : ""; // For styling into tab view


### PR DESCRIPTION
Hi there! 👋

First, I want to thank you for developing the awesome `trackswitch.js` tool. It’s been incredibly helpful for my projects!

In my specific use case, I needed the ability to preselect some audio tracks to either **mute** or **solo**, having more options to configure **mute** and **solo** settings for individual audio tracks directly from the HTML. To achieve this, I modified the following line of code: b384931fd3a741bddfecc776c29b83e7fdbf9c6b

With this update, you can now set the _initial_ **mute** and **solo** states using attributes in the `<ts-track>` DOM element, like `<ts-track title="Track" mute>` or `<ts-track title="Track" solo>`. This enhancement provides greater flexibility in managing audio tracks, particularly in applications with multiple tracks, where you want to **present a specific configuration to the listener** upfront, rather than having all tracks play simultaneously.

Here are two example use cases demonstrating how to utilize this feature:

## Example 1: Solo

Preselect **solo** for the `Drums` and `Bass` track.

```html
<div class="player">
    <p>
        An example trackswitch.js instance with preselected <b>solo</b> settings for individual tracks.
    </p>
    <img src="data/mix.png" class="seekable" data-seek-margin-left="3.5" data-seek-margin-right="4" />
    <ts-track title="Drums" data-img="data/drums.png" solo>
        <ts-source src="data/drums.mp3" type="audio/mpeg"></ts-source>
    </ts-track>
    <ts-track title="Bass" data-img="data/bass.png" solo>
        <ts-source src="data/bass.mp3" type="audio/mpeg"></ts-source>
    </ts-track>
    <ts-track title="Synth" data-img="data/synth.png">
        <ts-source src="data/synth.mp3" type="audio/mpeg"></ts-source>
    </ts-track>
    <ts-track title="Violins" data-img="data/violins.png">
        <ts-source src="data/violins.mp3" type="audio/mpeg"></ts-source>
    </ts-track>
</div>
```
<img width="679" alt="Bildschirmfoto 2024-09-30 um 08 35 05" src="https://github.com/user-attachments/assets/3ce3b2f8-f4f3-4f81-aff3-5f9b89784c19">

## Example 2: Mute

Preselect **mute** for the `Drums` and `Bass` track.

```html
<div class="player">
    <p>
        An example trackswitch.js instance with preselected <b>mute</b> settings for individual tracks.
    </p>
    <img src="data/mix.png" class="seekable" data-seek-margin-left="3.5" data-seek-margin-right="4" />
    <ts-track title="Drums" data-img="data/drums.png" mute>
        <ts-source src="data/drums.mp3" type="audio/mpeg"></ts-source>
    </ts-track>
    <ts-track title="Bass" data-img="data/bass.png" mute>
        <ts-source src="data/bass.mp3" type="audio/mpeg"></ts-source>
    </ts-track>
    <ts-track title="Synth" data-img="data/synth.png">
        <ts-source src="data/synth.mp3" type="audio/mpeg"></ts-source>
    </ts-track>
    <ts-track title="Violins" data-img="data/violins.png">
        <ts-source src="data/violins.mp3" type="audio/mpeg"></ts-source>
    </ts-track>
</div>
```
<img width="679" alt="Bildschirmfoto 2024-09-30 um 08 34 29" src="https://github.com/user-attachments/assets/78ea70dc-d96c-4b97-9cf9-d3eecb03d918">

---

I hope this addition proves useful to others and can be integrated into `trackswitch.js`.

Thank you for considering this contribution!

Best regards,
Peter