### PR TITLE
Add file size estimation and download progress display

### DIFF
--- a/css/trackswitch.css
+++ b/css/trackswitch.css
@@ -99,6 +99,14 @@
     color: #FFFFFF;
 }
 
+.jquery-trackswitch .overlay #overlaytext {
+    width: 100%;
+    top: calc(50% + 40px);
+    color: #FFFFFF;
+    font-size: 12pt;
+    text-align: center;
+}
+
 .jquery-trackswitch .overlay #overlayinfo {
     height: 40px;
     width: 100%;
@@ -369,6 +377,11 @@
     .jquery-trackswitch.error .overlay p {
         top: calc(50% + 45px);
 
+    }
+
+    .jquery-trackswitch .overlay #overlaytext {
+        top: calc(50% + 50px);
+        font-size: 11pt;
     }
 
 


### PR DESCRIPTION
This pull request adds estimated file size display and download progress features to the track switcher UI, enhancing user feedback during audio track loading #1 . The changes include new logic to estimate total download size before activation, live progress updates during download, and UI adjustments to display this information in the overlay.

**User Experience Improvements:**

* Added a new overlay element (`#overlaytext`) styled in `trackswitch.css` to display status messages such as estimated download size and live download progress. [[1]](diffhunk://#diff-24074d952ee6950666e9eac5925f89fc9e7d4f44b4247df1d3ae31102de494e0R102-R109) [[2]](diffhunk://#diff-24074d952ee6950666e9eac5925f89fc9e7d4f44b4247df1d3ae31102de494e0R382-R386)

**Download Progress and File Size Estimation:**

* Introduced logic to estimate and display the total download size before track activation, using `HEAD` or `GET` requests to retrieve file sizes for each track source. [[1]](diffhunk://#diff-30bed3760ae0fe80d76525dfe961f811336beb48a34c33ed689571b76c106e16R63-R65) [[2]](diffhunk://#diff-30bed3760ae0fe80d76525dfe961f811336beb48a34c33ed689571b76c106e16R368-R447)
* Implemented live download progress tracking for each track, aggregating progress and displaying it in the overlay during downloads. [[1]](diffhunk://#diff-30bed3760ae0fe80d76525dfe961f811336beb48a34c33ed689571b76c106e16R286-R305) [[2]](diffhunk://#diff-30bed3760ae0fe80d76525dfe961f811336beb48a34c33ed689571b76c106e16R323-R355)