### PR TITLE
Add global volume control slider

### DIFF
--- a/css/trackswitch.css
+++ b/css/trackswitch.css
@@ -196,6 +196,52 @@
     left: 0;
 }
 
+.jquery-trackswitch .main-control .volume-control {
+    float: left;
+    margin: 7px 10px 0 2px; /* Bring volume control to vertical center with 7px */
+    display: flex;
+    align-items: center;
+}
+
+.jquery-trackswitch .main-control .volume-icon {
+    font-family: FontAwesome;
+    font-size: 16px;
+    color: #DDDDDD;
+    margin-right: 8px;
+    width: 16px;
+    display: inline-block;
+    text-align: left;
+}
+
+.jquery-trackswitch .main-control .volume-slider {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 80px;
+    height: 4px;
+    background: #555;
+    outline: none;
+    cursor: pointer;
+}
+
+.jquery-trackswitch .main-control .volume-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 12px;
+    height: 12px;
+    background: #ED8C01;
+    cursor: pointer;
+    border-radius: 50%;
+}
+
+.jquery-trackswitch .main-control .volume-slider::-moz-range-thumb {
+    width: 12px;
+    height: 12px;
+    background: #ED8C01;
+    cursor: pointer;
+    border-radius: 50%;
+    border: none;
+}
+
 
 /* PLAYER TITLE STYLES ------------------------------------------------------ */
 
@@ -382,6 +428,15 @@
         margin: 4px 22px 0 0;
     }
 
+    .jquery-trackswitch .main-control .volume-control {
+        margin: 6px 5px 0 0;
+    }
+
+    .jquery-trackswitch .main-control .volume-control .volume-icon {
+        font-size: 20px;
+        width: 20px;
+    }
+
     .jquery-trackswitch .main-control .seekwrap {
         width: 100%;
         margin-top: 30px;
@@ -426,10 +481,21 @@
         margin: 0 14px; /* Share the spacing margin each side to center align */
     }
 
+    .jquery-trackswitch .main-control .volume-control {
+        float: none;
+        display: inline-flex;
+        margin: 32px 0 0 0;
+    }
+
+    .jquery-trackswitch .main-control .volume-control .volume-icon {
+        font-size: 20px;
+        width: 20px;
+    }
+
     .jquery-trackswitch .main-control .timing {
         width: 100%;
         float: none;
-        margin: 32px 0 8px 0;
+        margin: 16px 0 8px 0;
     }
 
     .jquery-trackswitch .main-control .seekwrap {


### PR DESCRIPTION
This pull request introduces a master volume control feature to the TrackSwitch player #17 .

**New volume control feature:**

* Added a volume slider and icon to the main player UI, allowing users to adjust the master volume (`js/trackswitch.js`, `css/trackswitch.css`). [[1]](diffhunk://#diff-30bed3760ae0fe80d76525dfe961f811336beb48a34c33ed689571b76c106e16R116-R121) [[2]](diffhunk://#diff-24074d952ee6950666e9eac5925f89fc9e7d4f44b4247df1d3ae31102de494e0R199-R244)
* Implemented a new gain node (`gainNodeVolume`) in the Web Audio API signal chain to control output volume, connecting it between the master gain node and the audio context destination (`js/trackswitch.js`). [[1]](diffhunk://#diff-30bed3760ae0fe80d76525dfe961f811336beb48a34c33ed689571b76c106e16R63) [[2]](diffhunk://#diff-30bed3760ae0fe80d76525dfe961f811336beb48a34c33ed689571b76c106e16L73-R82)

**Event handling and UI updates:**

* Added event handlers to update the audio volume in real time as the slider moves, and to prevent volume slider interactions from interfering with other player controls (`js/trackswitch.js`).
* Updated the volume icon dynamically to reflect the current volume level (muted, low, or high) for better user feedback (`js/trackswitch.js`).

**Responsive and style adjustments:**

* Added and adjusted CSS for the volume control and icon, including responsive tweaks for different screen sizes (`css/trackswitch.css`). [[1]](diffhunk://#diff-24074d952ee6950666e9eac5925f89fc9e7d4f44b4247df1d3ae31102de494e0R431-R439) [[2]](diffhunk://#diff-24074d952ee6950666e9eac5925f89fc9e7d4f44b4247df1d3ae31102de494e0R484-R498)

Screenshot:
<img width="980" height="49" alt="image" src="https://github.com/user-attachments/assets/84b8af37-7cbc-46f5-8d94-01dab3674610" />
